### PR TITLE
Use dedicated backend for healthcheck test

### DIFF
--- a/tests/test_fastly_healthchecks.py
+++ b/tests/test_fastly_healthchecks.py
@@ -27,10 +27,11 @@ class TestFastlyDirectors(TestCommon):
                 'check_interval'    : 15000,
                 'timeout'           : 5000,
             }],
-        })
-
-        healthcheck_configuration['backends'][0].update({
-            'healthcheck' : 'test_healthcheck',
+            'backends': [{
+                'name': 'localhost',
+                'address': '127.0.0.1',
+                'healthcheck' : 'test_healthcheck'
+            }],
         })
 
         configuration = FastlyConfiguration(healthcheck_configuration)


### PR DESCRIPTION
because otherwise the default backend is overwritten.
follow-up of https://github.com/Jimdo/ansible-fastly/pull/29